### PR TITLE
bugfix for searching with JCD fearture?

### DIFF
--- a/src/main/java/org/elasticsearch/index/query/image/AbstractImageScorer.java
+++ b/src/main/java/org/elasticsearch/index/query/image/AbstractImageScorer.java
@@ -43,7 +43,7 @@ public abstract class AbstractImageScorer extends Scorer {
         try {
             BytesRef bytesRef = binaryDocValues.get(docID());
             LireFeature docFeature = lireFeature.getClass().newInstance();
-            docFeature.setByteArrayRepresentation(bytesRef.bytes);
+            docFeature.setByteArrayRepresentation(bytesRef.bytes, bytesRef.offset, bytesRef.length);
 
             float distance = lireFeature.getDistance(docFeature);
             float score;


### PR DESCRIPTION
Hallo Jmoati, could you please check my change? (I'm sorry for my poor English.)
I noticed that the search with JCD feature didn't work:

The error message was something like this:

> ('{"error":{"root_cause":[{"type":"image_process_exception","reason":"Failed to calculate score"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"test_index","node":"jtUUrnnGSMauRQ0-nuregQ","reason":{"type":"image_process_exception","reason":"Failed to calculate score","caused_by":{"type":"array_index_out_of_bounds_exception","reason":"168"}}}]},"status":500}', None)

So, I changed the call from docFeature.setByteArrayRepresentation function to use offset and length.
I'm not sure whether it is correct, but at least the error doesn't  show up anymore on my environment.